### PR TITLE
Fix RTL direction in the description

### DIFF
--- a/src/routes/WatchVideo.vue
+++ b/src/routes/WatchVideo.vue
@@ -104,7 +104,7 @@
                                 </div>
                             </div>
                         </router-link>
-                        <div class="mt-4" v-html="video.description" />
+                        <div class="mt-4" dir="auto" v-html="video.description" />
                         <v-divider class="my-4" />
                         <div class="mt-4" v-if="showDesc && sponsors && sponsors.segments">
                             Sponsors Segments: {{ sponsors.segments.length }}


### PR DESCRIPTION
This allows the browser to detect if the text is RTL to automatically set the direction on the test.

before:
![before dir="auto"](https://github.com/mmjee/Piped-Material/assets/31791780/d864d2a8-3697-4a8e-b670-16cc7fb09a9a)

after:
![after dir="auto"](https://github.com/mmjee/Piped-Material/assets/31791780/4d9b413c-2df3-4fc8-b162-3a5fc5d5b0df)
